### PR TITLE
feat: add severity level param

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # danger-checkstyle_format
 
-Danger plugin that parses a checkstyle format xml file into a PR reports.
+Danger plugin that parses a checkstyle format xml file turns it into a Pull Request static analysis report.
 
 ## Installation
 ``` bashrc
@@ -10,10 +10,9 @@ $ gem "danger-checkstyle_format", github: "iurysza/danger-checkstyle_format"
 
 Parse the XML file, and let the plugin do the reporting.
 - `gradle_task`: You can provide a custom `gradle` task to run before the report. This task can be used to create the checkstyle format file.
-- `severity_level`: You can _force_ the plugin to use a severity level for all issues on the report.
-ie.: `"warning" | "error"`
+- `severity_level`: You can _force_ the plugin to use a severity level for all issues on the report. That can either be: `"warning" | "error"`
 - `report(file, inline_mode = true)`: The file path of the checkstyle format file and weather to report issues with inline comments or not.
-- `base_path`: Base path of `name` attribute in the checkstyle `file` tag.
+- `base_path`: Base path of `name` attribute in the checkstyle `file` tag, usually that's the working directory. (`Dir.pwd` in ruby)
 Eg.:
 
 ``` xml
@@ -22,10 +21,15 @@ Eg.:
       ...
 </checkstyle>
 ```
-An example of this using plugin to apply Kotlin's `detekt` with via a gradle task.
+An example of the usage of this plugin to apply Kotlin's static analysis tools: [detekt](https://github.com/detekt/detekt) and ([ktlint](https://ktlint.github.io/):
 ``` ruby
 checkstyle_format.base_path = Dir.pwd
 checkstyle_format.gradle_task = "detektCi"
+checkstyle_format.report 'build/reports/detekt/checkstyle.xml'
+
+checkstyle_format.base_path = Dir.pwd
+checkstyle_format.gradle_task = "ktlintCi"
+# here we're forcing ktlint issues to be reported as errors.
 checkstyle_format.severity_level = "error"
 checkstyle_format.report 'build/reports/ktlint/checkstyle.xml'
 ```

--- a/README.md
+++ b/README.md
@@ -1,26 +1,30 @@
-[![Build Status](https://travis-ci.org/noboru-i/danger-checkstyle_format.svg?branch=master)](https://travis-ci.org/noboru-i/danger-checkstyle_format)
-
 # danger-checkstyle_format
 
-Danger plugin for checkstyle formatted xml file.
+Danger plugin that parses a checkstyle format xml file into a PR reports.
 
 ## Installation
-
-    $ gem install danger-checkstyle_format
-
+``` bashrc
+$ gem "danger-checkstyle_format", github: "iurysza/danger-checkstyle_format"
+```
 ## Usage
 
-<blockquote>Parse the XML file, and let the plugin do your reporting
-  <pre>
-checkstyle_format.base_path = Dir.pwd
-checkstyle_format.report 'app/build/reports/checkstyle/checkstyle.xml'</pre>
-</blockquote>
+Parse the XML file, and let the plugin do the reporting.
+- `gradle_task`: You can provide a custom `gradle` task to run before the report. This task can be used to create the checkstyle format file.
+- `severity_level`: You can _force_ the plugin to use a severity level for all issues on the report.
+ie.: `"warning" | "error"`
+- `report(file, inline_mode = true)`: The file path of the checkstyle format file.
+``` ruby
+checkstyle_format.gradle_task = "detektCi"
+checkstyle_format.severity_level = "error"
+checkstyle_format.report 'build/reports/ktlint/checkstyle.xml'
 
-<blockquote>Parse the XML text, and let the plugin do your reporting
-  <pre>
+```
+
+Parse the XML text, and let the plugin do your reporting
+``` ruby
 checkstyle_format.base_path = Dir.pwd
-checkstyle_format.report_by_text '<?xml ...'</pre>
-</blockquote>
+checkstyle_format.report_by_text '<?xml ...'
+```
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -12,13 +12,24 @@ Parse the XML file, and let the plugin do the reporting.
 - `gradle_task`: You can provide a custom `gradle` task to run before the report. This task can be used to create the checkstyle format file.
 - `severity_level`: You can _force_ the plugin to use a severity level for all issues on the report.
 ie.: `"warning" | "error"`
-- `report(file, inline_mode = true)`: The file path of the checkstyle format file.
+- `report(file, inline_mode = true)`: The file path of the checkstyle format file and weather to report issues with inline comments or not.
+- `base_path`: Base path of `name` attribute in the checkstyle `file` tag.
+Eg.:
+
+``` xml
+<checkstyle>
+    <file name="base_path/path/to/file">
+      ...
+</checkstyle>
+```
+An example of this using plugin to apply Kotlin's `detekt` with via a gradle task.
 ``` ruby
+checkstyle_format.base_path = Dir.pwd
 checkstyle_format.gradle_task = "detektCi"
 checkstyle_format.severity_level = "error"
 checkstyle_format.report 'build/reports/ktlint/checkstyle.xml'
-
 ```
+
 
 Parse the XML text, and let the plugin do your reporting
 ``` ruby

--- a/lib/checkstyle_format/plugin.rb
+++ b/lib/checkstyle_format/plugin.rb
@@ -23,10 +23,15 @@ module Danger
     attr_accessor :base_path
 
     # Custom gradle task to run.
-    # This is useful when your project has different flavors.
+    # This is the name of the gradle task that will create 
+    # the check style xml file that this plugin will read
     # @return [String]
     attr_accessor :gradle_task
 
+    # Forces this severity level for all issues
+    # "none" | "warning" | "error"
+    attr_accessor :severity_level
+    
     def gradlew_exists?
       `ls gradlew`.strip.empty? == false
     end
@@ -84,9 +89,10 @@ module Danger
         file = inline_mode && !issue.file_name.nil? && issue.file_name ? issue.file_name : nil
         line = inline_mode && !issue.line.nil? && issue.line > 0 ? issue.line : nil
 
-        if issue.severity == "error" or gradle_task.include? 'detekt' or gradle_task.include? 'ktlint'
+        # Will report error if the task used to create the output file has "detekt" or "ktlint" in its name
+        if issue.severity == "error" or severity_level.include? "error"
           fail(issue.message, file: file, line: line)
-        elsif issue.severity == "warning"
+        elsif issue.severity == "warning" or severity_level.include? "warning"
           warn(issue.message, file: file, line: line)
         else
           message(issue.message, file: file, line: line)

--- a/lib/checkstyle_format/plugin.rb
+++ b/lib/checkstyle_format/plugin.rb
@@ -92,9 +92,10 @@ module Danger
         file = inline_mode && !issue.file_name.nil? && issue.file_name ? issue.file_name : nil
         line = inline_mode && !issue.line.nil? && issue.line > 0 ? issue.line : nil
 
-        if issue.severity == "error" or severity_level.include? "error"
+        severity = severity_level == nil ?  issue.severity ?: severity_level
+        if severity == "error"
           fail(issue.message, file: file, line: line)
-        elsif issue.severity == "warning" or severity_level.include? "warning"
+        elsif severity == "warning"
           warn(issue.message, file: file, line: line)
         else
           message(issue.message, file: file, line: line)

--- a/lib/checkstyle_format/plugin.rb
+++ b/lib/checkstyle_format/plugin.rb
@@ -3,10 +3,13 @@ require_relative "checkstyle_error"
 module Danger
   # Danger plugin for checkstyle formatted xml file.
   #
-  # @example Parse the XML file, and let the plugin do your reporting
-  #
+  # @example Using gradle to run a detekt task that spits a report file.
+  # Then, parse the XML file while forcing all issues to have error status.
+  # 
   #          checkstyle_format.base_path = Dir.pwd
-  #          checkstyle_format.report 'app/build/reports/checkstyle/checkstyle.xml'
+  #          checkstyle_format.gradle_task = "detektCi"
+  #          checkstyle_format.severity_level = "error"
+  #          checkstyle_format.report 'build/reports/detekt/checkstyle.xml'
   #
   # @example Parse the XML text, and let the plugin do your reporting
   #
@@ -18,11 +21,11 @@ module Danger
   #
   class DangerCheckstyleFormat < Plugin
     # Base path of `name` attributes in `file` tag.
-    # Defaults to nil.
+    # Defaults to Dir.pwd.
     # @return [String]
     attr_accessor :base_path
 
-    # Custom gradle task to run.
+    # Optional gradle task to run.
     # This is the name of the gradle task that will create 
     # the check style xml file that this plugin will read
     # @return [String]
@@ -31,6 +34,10 @@ module Danger
     # Forces this severity level for all issues
     # "none" | "warning" | "error"
     attr_accessor :severity_level
+    
+    def initialize
+      @base_path = 'Dir.pwd'    
+    end
     
     def gradlew_exists?
       `ls gradlew`.strip.empty? == false
@@ -89,7 +96,6 @@ module Danger
         file = inline_mode && !issue.file_name.nil? && issue.file_name ? issue.file_name : nil
         line = inline_mode && !issue.line.nil? && issue.line > 0 ? issue.line : nil
 
-        # Will report error if the task used to create the output file has "detekt" or "ktlint" in its name
         if issue.severity == "error" or severity_level.include? "error"
           fail(issue.message, file: file, line: line)
         elsif issue.severity == "warning" or severity_level.include? "warning"

--- a/lib/checkstyle_format/plugin.rb
+++ b/lib/checkstyle_format/plugin.rb
@@ -92,7 +92,7 @@ module Danger
         file = inline_mode && !issue.file_name.nil? && issue.file_name ? issue.file_name : nil
         line = inline_mode && !issue.line.nil? && issue.line > 0 ? issue.line : nil
 
-        severity = severity_level == nil ?  issue.severity ?: severity_level
+        severity = severity_level == nil ?  issue.severity : severity_level
         if severity == "error"
           fail(issue.message, file: file, line: line)
         elsif severity == "warning"

--- a/lib/checkstyle_format/plugin.rb
+++ b/lib/checkstyle_format/plugin.rb
@@ -35,10 +35,6 @@ module Danger
     # "none" | "warning" | "error"
     attr_accessor :severity_level
     
-    def initialize(base_path='Dir.pwd', gradle_task='', severity_level='')
-      @base_path = base_path
-    end
-    
     def gradlew_exists?
       `ls gradlew`.strip.empty? == false
     end
@@ -47,7 +43,7 @@ module Danger
     #
     # @return   [void]
     def report(file, inline_mode = true)
-
+      
       unless gradlew_exists?
         raise "Could not find `gradlew` inside current directory"
       end

--- a/lib/checkstyle_format/plugin.rb
+++ b/lib/checkstyle_format/plugin.rb
@@ -35,8 +35,8 @@ module Danger
     # "none" | "warning" | "error"
     attr_accessor :severity_level
     
-    def initialize
-      @base_path = 'Dir.pwd'    
+    def initialize(base_path='Dir.pwd', gradle_task, severity_level)
+      @base_path = base_path
     end
     
     def gradlew_exists?

--- a/lib/checkstyle_format/plugin.rb
+++ b/lib/checkstyle_format/plugin.rb
@@ -35,7 +35,7 @@ module Danger
     # "none" | "warning" | "error"
     attr_accessor :severity_level
     
-    def initialize(base_path='Dir.pwd', gradle_task, severity_level)
+    def initialize(base_path='Dir.pwd', gradle_task='', severity_level='')
       @base_path = base_path
     end
     


### PR DESCRIPTION
# Context
There's no way to force a severity level.
There is an implicit logic that relies on the `gradle_task` parameter.

With the `severity_level` parameter we could enable the user to choose the severity level explicitly.